### PR TITLE
Simplify container deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 Deploy and configure [Traefik](https://doc.traefik.io/traefik/) docker container
 
-Docker socket is protected by [tecnativa/docker-socket-proxy](https://hub.docker.com/r/tecnativa/docker-socket-proxy) with the minimum necessary access.
-
 Clean role execution will give you:
   - running traefik instance on 80 port
   - enabled traefik dashboard secured with basic authentication
@@ -20,7 +18,6 @@ Clean role execution will give you:
 Docker daemon and Docker SDK for Python is required on target host
 
 ## Dependencies
-
 Minimal playbook to install Docker daemon and SDK on Debian family OS
 ```sh
 ansible-galaxy role install bonddim.docker
@@ -50,6 +47,7 @@ ansible-galaxy role install bonddim.docker geerlingguy.pip
     - role: geerlingguy.pip
       pip_install_packages: docker
 ```
+
 ## Role Variables
 Variables with default values from _defaults/main.yml_
 ```yaml
@@ -81,6 +79,7 @@ traefik_acme_staging: false  # enable staging server for debug
 traefik_provider_docker: true  # enable/disable docker provider
 traefik_provider_docker_exposebydefault: false  # enable/disable expose by default
 traefik_provider_docker_defaultrule: ""  # default rule for docker provider
+traefik_provider_docker_endpoint: unix:///var/run/docker.sock  # default docker endpoint
 traefik_http_routes: []  # user-defined http routes to other servers/services on host/network
   # - name: ""  # required
   #   rule: ""  # optional. Default is 'Host(`route_name.traefik_host_domainname`)' or 'Host(`route_name`)'
@@ -91,7 +90,6 @@ traefik_http_routes: []  # user-defined http routes to other servers/services on
 ```
 
 ## Example Playbook
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 ```yaml
 - name: minimal setup with http
   hosts: all

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ traefik_acme_staging: false  # enable staging server for debug
 traefik_provider_docker: true  # enable/disable docker provider
 traefik_provider_docker_exposebydefault: false  # enable/disable expose by default
 traefik_provider_docker_defaultrule: ""  # default rule for docker provider
-traefik_provider_docker_endpoint: unix:///var/run/docker.sock  # default docker endpoint
+traefik_provider_docker_endpoint: ""  # default docker endpoint unix:///var/run/docker.sock
 traefik_http_routes: []  # user-defined http routes to other servers/services on host/network
   # - name: ""  # required
   #   rule: ""  # optional. Default is 'Host(`route_name.traefik_host_domainname`)' or 'Host(`route_name`)'

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ ansible-galaxy role install bonddim.docker geerlingguy.pip
 Variables with default values from _defaults/main.yml_
 ```yaml
 traefik_data: /opt/traefik  # path on host to store traefik data
-traefik_network: traefik-proxy  # docker network name for traefik proxy
-docker_socket_proxy: socket-proxy  # docker network name for docker socket proxy container
+traefik_docker_network: bridge  # docker network name for traefik proxy
 traefik_host_domainname: ""  # your domain name
 traefik_env: {}  # dict with environment variables, mostly used for acme dns provider settings
 traefik_dashboard_enable: true  # enable/disable dashboard

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,6 @@
 # defaults file for traefik role
 traefik_data: /opt/traefik
 traefik_network: traefik-proxy
-docker_socket_proxy: socket-proxy
 
 traefik_host_domainname: ""
 traefik_env: {}
@@ -48,6 +47,7 @@ traefik_acme_storage_file: "{{ traefik_data }}/acme.json"
 traefik_provider_docker: true
 traefik_provider_docker_exposebydefault: false
 traefik_provider_docker_defaultrule: ""
+traefik_provider_docker_endpoint: unix:///var/run/docker.sock
 
 # Custom routes
 traefik_http_routes: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@ traefik_acme_storage_file: "{{ traefik_data }}/acme.json"
 traefik_provider_docker: true
 traefik_provider_docker_exposebydefault: false
 traefik_provider_docker_defaultrule: ""
-traefik_provider_docker_endpoint: unix:///var/run/docker.sock
+traefik_provider_docker_endpoint: ""
 
 # Custom routes
 traefik_http_routes: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for traefik role
 traefik_data: /opt/traefik
-traefik_network: traefik-proxy
+traefik_docker_network: bridge
 
 traefik_host_domainname: ""
 traefik_env: {}

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -26,7 +26,7 @@
         state: started
         container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
         networks:
-          - name: "{{ traefik_network }}"
+          - name: "{{ traefik_docker_network }}"
         networks_cli_compatible: true
         network_mode: default
         labels:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,12 +72,6 @@
       - --configfile "{{ traefik_configfile_static }}"
     env: "{{ traefik_env }}"
     volumes: "{{ traefik_mount_volumes | select | list }}"
-    labels:
-      traefik.enable: "{{ traefik_dashboard_enable | string }}"
-      traefik.http.routers.traefik.service: api@internal
-      traefik.http.routers.traefik.rule: "{{ traefik_host_domainname | ternary(omit, 'PathPrefix(`/api`) || PathPrefix(`/dashboard`)') }}"
-      traefik.http.routers.traefik.entrypoints: "{{ traefik_enable_https | ternary('websecure', 'web') }}"
-      traefik.http.routers.traefik.middlewares: "{{ traefik_dashboard_middlewares }}"
   vars:
     traefik_mount_volumes:
       - "{{ traefik_data }}:{{ traefik_data }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,13 +71,15 @@
     command:
       - --configfile "{{ traefik_configfile_static }}"
     env: "{{ traefik_env }}"
-    volumes:
-      - "/etc/localtime:/etc/localtime:ro"
-      - "{{ traefik_data }}:{{ traefik_data }}"
+    volumes: "{{ traefik_mount_volumes | select | list }}"
     labels:
       traefik.enable: "{{ traefik_dashboard_enable | string }}"
       traefik.http.routers.traefik.service: api@internal
       traefik.http.routers.traefik.rule: "{{ traefik_host_domainname | ternary(omit, 'PathPrefix(`/api`) || PathPrefix(`/dashboard`)') }}"
       traefik.http.routers.traefik.entrypoints: "{{ traefik_enable_https | ternary('websecure', 'web') }}"
       traefik.http.routers.traefik.middlewares: "{{ traefik_dashboard_middlewares }}"
+  vars:
+    traefik_mount_volumes:
+      - "{{ traefik_data }}:{{ traefik_data }}"
+      - "{{ traefik_provider_docker_endpoint | ternary('', '/var/run/docker.sock:/var/run/docker.sock:ro') }}"
   tags: traefik, traefik-container

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,8 @@
 
 - name: Ensure docker networks state
   docker_network:
-    name: "{{ item }}"
+    name: "{{ traefik_network }}"
     state: present
-  loop:
-    - "{{ traefik_network }}"
-    - "{{ docker_socket_proxy }}"
   tags: traefik, traefik-networks
 
 - name: Ensure traefik data directory state
@@ -51,30 +48,6 @@
   register: traefik_config
   tags: traefik, traefik-config
 
-- name: Launch docker-socket-proxy
-  docker_container:
-    name: "{{ docker_socket_proxy }}"
-    image: tecnativa/docker-socket-proxy:latest
-    pull: true
-    ignore_image: false
-    state: started
-    recreate: false
-    restart: false
-    restart_policy: unless-stopped
-    container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
-    networks:
-      - name: "{{ docker_socket_proxy }}"
-    networks_cli_compatible: true
-    network_mode: default
-    security_opts:
-      - no-new-privileges:true
-    env:
-      CONTAINERS: '1'
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-  tags: traefik, traefik-socket
-
-
 - name: Launch traefik container
   docker_container:
     name: traefik
@@ -88,7 +61,6 @@
     container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
     networks:
       - name: "{{ traefik_network }}"
-      - name: "{{ docker_socket_proxy }}"
     networks_cli_compatible: true
     network_mode: default
     security_opts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,9 @@
   import_tasks: assert.yml
   tags: traefik, assert
 
-- name: Ensure docker networks state
+- name: Ensure traefik docker network state
   docker_network:
-    name: "{{ traefik_network }}"
+    name: "{{ traefik_docker_network }}"
     state: present
   tags: traefik, traefik-networks
 
@@ -60,7 +60,7 @@
     restart_policy: unless-stopped
     container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
     networks:
-      - name: "{{ traefik_network }}"
+      - name: "{{ traefik_docker_network }}"
     networks_cli_compatible: true
     network_mode: default
     security_opts:

--- a/templates/dynamic.yaml.j2
+++ b/templates/dynamic.yaml.j2
@@ -2,6 +2,15 @@
 ### {{ ansible_managed }}
 http:
   routers:
+  {% if traefik_dashboard_enable %}
+    traefik:
+      entrypoints: [ {{ traefik_enable_https | ternary('websecure', 'web') }} ]
+      rule: {% if traefik_host_domainname %}"Host(`traefik.{{ traefik_host_domainname }}`)"
+            {% else %}"PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+            {% endif %}
+      service: api@internal
+      middlewares: {{ traefik_dashboard_middlewares }}
+  {% endif %}
   {% for item in traefik_http_routes %}
     {{ item.name }}:
       entrypoints: [ {{ traefik_enable_https | ternary('websecure', 'web') }} ]

--- a/templates/static.yaml.j2
+++ b/templates/static.yaml.j2
@@ -59,7 +59,9 @@ providers:
     defaultRule: "Host(`{{ '{{ normalize .Name }}' }}.{{ traefik_host_domainname }}`)"
     {% endif %}
     exposedByDefault: {{ traefik_provider_docker_exposebydefault }}
+    {% if traefik_provider_docker_endpoint %}
     endpoint: {{ traefik_provider_docker_endpoint }}
+    {% endif %}
     network: {{ traefik_network }}
   {% endif %}
 

--- a/templates/static.yaml.j2
+++ b/templates/static.yaml.j2
@@ -62,7 +62,9 @@ providers:
     {% if traefik_provider_docker_endpoint %}
     endpoint: {{ traefik_provider_docker_endpoint }}
     {% endif %}
-    network: {{ traefik_network }}
+    {% if traefik_docker_network != 'bridge' %}
+    network: {{ traefik_docker_network }}
+    {% endif %}
   {% endif %}
 
   # File configuration backend

--- a/templates/static.yaml.j2
+++ b/templates/static.yaml.j2
@@ -59,7 +59,7 @@ providers:
     defaultRule: "Host(`{{ '{{ normalize .Name }}' }}.{{ traefik_host_domainname }}`)"
     {% endif %}
     exposedByDefault: {{ traefik_provider_docker_exposebydefault }}
-    endpoint: "tcp://{{ docker_socket_proxy }}:2375"
+    endpoint: {{ traefik_provider_docker_endpoint }}
     network: {{ traefik_network }}
   {% endif %}
 


### PR DESCRIPTION
- Remove docker socket proxy
- Mount host docker socket if docker endpoint is empty
- Use default bridge network
- Move dashboard config to file
