### PR TITLE
development

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -15,6 +15,11 @@ jobs:
     defaults:
       run:
         working-directory: bonddim.traefik
+    strategy:
+      matrix:
+        install_method:
+          - binary
+          - container
 
     steps:
       - name: Checks-out repository
@@ -36,5 +41,6 @@ jobs:
       - name: Run Molecule tests
         run: molecule test
         env:
+          INSTALL_METHOD: ${{ matrix.install_method }}
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/bonddim/ansible-role-traefik)](https://github.com/bonddim/ansible-role-traefik/blob/main/LICENSE)
 
 
-Deploy and configure [Traefik](https://doc.traefik.io/traefik/) docker container
+Deploy and configure [Traefik v2](https://doc.traefik.io/traefik/)
 
 Clean role execution will give you:
   - running traefik instance on 80 port
@@ -15,13 +15,13 @@ Clean role execution will give you:
   - security options for https
 
 ## Requirements
-Docker daemon and Docker SDK for Python is required on target host
+Docker daemon and Docker SDK for Python is required on target host if **container** install method selected (see [variables](#role-variables) section)
 
-## Dependencies
 Minimal playbook to install Docker daemon and SDK on Debian family OS
 ```sh
 ansible-galaxy role install bonddim.docker
 ```
+
 ```yaml
 ---
 - hosts: Debian,Ubuntu
@@ -34,6 +34,7 @@ ansible-galaxy role install bonddim.docker
         name: python3-docker
         state: present
 ```
+
 Install Docker SDK from pip
 ```sh
 ansible-galaxy role install bonddim.docker geerlingguy.pip
@@ -49,18 +50,35 @@ ansible-galaxy role install bonddim.docker geerlingguy.pip
 ```
 
 ## Role Variables
-Variables with default values from _defaults/main.yml_
+Variables with default values from [defaults/main.yml](https://github.com/bonddim/ansible-role-traefik/blob/main/defaults/main.yml)
+
 ```yaml
-traefik_home: /opt/traefik  # path on host to store traefik data
-traefik_docker_network: bridge  # docker network name for traefik proxy
+# Common vars
+traefik_home: /etc/traefik  # path on host to store traefik data
+traefik_version: latest  # version to install, ex. v2.3.4
+traefik_install_method: binary   # possible values: binary, container
 traefik_host_domainname: ""  # your domain name
 traefik_env: {}  # dict with environment variables, mostly used for acme dns provider settings
+
+# Binary related vars
+traefik_install_path: /usr/local/bin/traefik  # path to install traefik binary
+
+# Container related vars
+traefik_docker_network: bridge  # docker network name for traefik proxy
+
+# Dashboard
 traefik_dashboard_enable: true  # enable/disable dashboard
 traefik_dashboard_middlewares: auth-basic@file  # apply middlewares for dashboard
+
+# Basic auth
 traefik_basic_auth_user: admin  # user name for basic auth
 traefik_basic_auth_pass: $apr1$MR6nE9XC$lC2fnUmGLmsZDGqNlcdxU0  # password for basic auth generated with htpasswd (admin)
+
+# Logs
 traefik_log_level: ERROR  # traefik log level
 traefik_log_format: json  # traefik log format
+
+# HTTPS
 traefik_enable_https: false  # enable/disable https entrypoint
 traefik_enable_https_redirect: true  # create permanent redirect from http to https
 traefik_tls_config: modern  # tls settings https://ssl-config.mozilla.org
@@ -70,15 +88,20 @@ traefik_tls_certificates: []  # list of user certificates when traefik_tls_resol
   #   key: /path/to/key
   # - cert: /path/to/another/cert
   #   key: /path/to/another/key
+
 # ACME (Let's Encrypt) https://doc.traefik.io/traefik/https/acme
 traefik_acme_email: ""  # email for acme registration
 traefik_acme_challenge: dns  # possible values: dns, tls, http
 traefik_acme_dns_provider: ""  # your dns provider
 traefik_acme_staging: false  # enable staging server for debug
+
+# Providers
 traefik_provider_docker: true  # enable/disable docker provider
 traefik_provider_docker_exposebydefault: false  # enable/disable expose by default
 traefik_provider_docker_defaultrule: ""  # default rule for docker provider
 traefik_provider_docker_endpoint: ""  # default docker endpoint unix:///var/run/docker.sock
+
+# Custom routes
 traefik_http_routes: []  # user-defined http routes to other servers/services on host/network
   # - name: ""  # required
   #   rule: ""  # optional. Default is 'Host(`route_name.traefik_host_domainname`)' or 'Host(`route_name`)'
@@ -92,6 +115,22 @@ traefik_http_routes: []  # user-defined http routes to other servers/services on
 ```yaml
 - name: minimal setup with http
   hosts: all
+  roles:
+    - bonddim.traefik
+
+- name: deploy traefik container and enable docker provider
+  hosts: all
+  vars:
+    traefik_install_method: container
+    traefik_provider_docker: true
+  roles:
+    - bonddim.traefik
+
+- name: enable docker provider with tcp endpoint to docker socket
+  hosts: all
+  vars:
+    traefik_provider_docker: true
+    traefik_provider_docker_endpoint: "tcp://host:port"
   roles:
     - bonddim.traefik
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ansible-galaxy role install bonddim.docker geerlingguy.pip
 ## Role Variables
 Variables with default values from _defaults/main.yml_
 ```yaml
-traefik_data: /opt/traefik  # path on host to store traefik data
+traefik_home: /opt/traefik  # path on host to store traefik data
 traefik_docker_network: bridge  # docker network name for traefik proxy
 traefik_host_domainname: ""  # your domain name
 traefik_env: {}  # dict with environment variables, mostly used for acme dns provider settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ traefik_acme_dns_disablepropagationcheck: false
 traefik_acme_staging: false
 
 # Providers
-traefik_provider_docker: true
+traefik_provider_docker: false
 traefik_provider_docker_exposebydefault: false
 traefik_provider_docker_defaultrule: ""
 traefik_provider_docker_endpoint: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,10 +6,6 @@ traefik_docker_network: bridge
 traefik_host_domainname: ""
 traefik_env: {}
 
-# Config files
-traefik_configfile_static: "{{ traefik_data }}/static.yaml"
-traefik_configfile_dynamic: "{{ traefik_data }}/dynamic.yaml"
-
 # Dashboard
 traefik_dashboard_enable: true
 traefik_dashboard_middlewares: auth-basic@file
@@ -41,7 +37,6 @@ traefik_acme_challenge: dns  # possible values: dns, tls, http
 traefik_acme_dns_provider: ""
 traefik_acme_dns_disablepropagationcheck: false
 traefik_acme_staging: false
-traefik_acme_storage_file: "{{ traefik_data }}/acme.json"
 
 # Providers
 traefik_provider_docker: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,21 @@
 ---
 # defaults file for traefik role
-traefik_home: /opt/traefik
+# Common vars
+traefik_home: /etc/traefik
 traefik_user: traefik
 traefik_group: traefik
 
-traefik_docker_network: bridge
+traefik_version: latest
+traefik_install_method: container  ## possible values: binary, container
 
 traefik_host_domainname: ""
 traefik_env: {}
+
+# Binary related vars
+traefik_install_path: /usr/local/bin/traefik
+
+# Container related vars
+traefik_docker_network: bridge
 
 # Dashboard
 traefik_dashboard_enable: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for traefik role
 traefik_home: /opt/traefik
+traefik_user: traefik
+traefik_group: traefik
+
 traefik_docker_network: bridge
 
 traefik_host_domainname: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for traefik role
-traefik_data: /opt/traefik
+traefik_home: /opt/traefik
 traefik_docker_network: bridge
 
 traefik_host_domainname: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ traefik_user: traefik
 traefik_group: traefik
 
 traefik_version: latest
-traefik_install_method: container  ## possible values: binary, container
+traefik_install_method: binary  ## possible values: binary, container
 
 traefik_host_domainname: ""
 traefik_env: {}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,22 @@
+---
+# handlers file for traefik role
+- name: Reload systemd daemon and activate traefik
+  systemd:
+    name: traefik.service
+    state: restarted
+    enabled: true
+    daemon_reload: true
+  listen: daemon_reload
+
+- name: Start traefik service
+  systemd:
+    name: traefik.service
+    state: started
+  listen: traefik_start
+
+- name: Restart traefik service
+  systemd:
+    name: traefik.service
+    state: restarted
+  listen: traefik_restart
+  when: traefik_install_method == 'binary'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   license: "license (MIT)"
 
   role_name: traefik
-  description: "Deploy traefik container with TLS support"
+  description: "Deploy traefik v2 with TLS support"
   github_branch: main
 
   min_ansible_version: 2.9

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,17 +3,22 @@
   hosts: all
   gather_facts: true
   become: true
+  vars:
+    traefik_install_method: "{{ lookup('env', 'INSTALL_METHOD') }}"
+    traefik_provider_docker: "{{ (traefik_install_method == 'container') | ternary(true, false) }}"
 
   pre_tasks:
-    - name: Install Docker daemon
-      include_role:
-        name: bonddim.docker
-      when: not "docker0" in ansible_interfaces
+    - when: traefik_install_method == 'container'
+      block:
+        - name: Install Docker daemon
+          include_role:
+            name: bonddim.docker
+          when: not "docker0" in ansible_interfaces
 
-    - name: Install docker python library
-      package:
-        name: python3-docker
-        state: present
+        - name: Install docker python library
+          package:
+            name: python3-docker
+            state: present
 
   roles:
     - bonddim.traefik

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,5 +13,9 @@ platforms:
       alias: "${MOLECULE_DISTRO:-ubuntu/18.04}"
 provisioner:
   name: ansible
+  env:
+    INSTALL_METHOD: "${INSTALL_METHOD:-binary}"
 verifier:
   name: ansible
+  env:
+    INSTALL_METHOD: "${INSTALL_METHOD:-binary}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,6 @@
 - name: Verify
   hosts: all
   gather_facts: false
-
   vars_files:
     - "{{ playbook_dir }}/../../defaults/main.yml"
 
@@ -19,28 +18,29 @@
       retries: 3
       delay: 5
 
-    - name: Start whoami container
-      docker_container:
-        name: whoami
-        image: traefik/whoami:latest
-        state: started
-        container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
-        networks:
-          - name: "{{ traefik_docker_network }}"
-        networks_cli_compatible: true
-        network_mode: default
-        labels:
-          traefik.enable: "true"
+    - when: lookup('env', 'INSTALL_METHOD') == 'container'
+      block:
+        - name: Start whoami container
+          docker_container:
+            name: whoami
+            image: traefik/whoami:latest
+            state: started
+            container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
+            networks:
+              - name: "{{ traefik_docker_network }}"
+            networks_cli_compatible: true
+            network_mode: default
+            labels:
+              traefik.enable: "true"
 
-
-    - name: Send request to whoami
-      uri:
-        url: http://127.0.0.1
-        follow_redirects: none
-        method: GET
-        headers:
-          Host: whoami
-      register: whoami
-      until: whoami.status == 200
-      retries: 3
-      delay: 5
+        - name: Send request to whoami
+          uri:
+            url: http://127.0.0.1
+            follow_redirects: none
+            method: GET
+            headers:
+              Host: whoami
+          register: whoami
+          until: whoami.status == 200
+          retries: 3
+          delay: 5

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,0 +1,15 @@
+---
+- name: Generate traefik config files
+  become: true
+  template:
+    dest: "{{ item.dest }}"
+    src: "{{ item.src }}"
+    lstrip_blocks: true
+    trim_blocks: true
+    owner: root
+    group: root
+    mode: 0640
+  loop:
+    - { src: static.yaml.j2, dest: "{{ traefik_configfile_static }}" }
+    - { src: dynamic.yaml.j2, dest: "{{ traefik_configfile_dynamic }}" }
+  register: traefik_config

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,8 +5,8 @@
     src: static.yaml.j2
     lstrip_blocks: true
     trim_blocks: true
-    owner: root
-    group: root
+    owner: "{{ traefik _user }}"
+    group: "{{ traefik_group }}"
     mode: 0640
   register: _traefik_restart
 
@@ -16,6 +16,6 @@
     src: dynamic.yaml.j2
     lstrip_blocks: true
     trim_blocks: true
-    owner: root
-    group: root
+    owner: "{{ traefik _user }}"
+    group: "{{ traefik_group }}"
     mode: 0640

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,6 +9,7 @@
     group: "{{ traefik_group }}"
     mode: 0640
   register: _traefik_restart
+  notify: traefik_restart
 
 - name: Generate dynamic config file
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,15 +1,21 @@
 ---
-- name: Generate traefik config files
-  become: true
+- name: Generate static config file
   template:
-    dest: "{{ item.dest }}"
-    src: "{{ item.src }}"
+    dest: "{{ traefik_configfile_static }}"
+    src: static.yaml.j2
     lstrip_blocks: true
     trim_blocks: true
     owner: root
     group: root
     mode: 0640
-  loop:
-    - { src: static.yaml.j2, dest: "{{ traefik_configfile_static }}" }
-    - { src: dynamic.yaml.j2, dest: "{{ traefik_configfile_dynamic }}" }
-  register: traefik_config
+  register: _traefik_restart
+
+- name: Generate dynamic config file
+  template:
+    dest: "{{ traefik_configfile_dynamic }}"
+    src: dynamic.yaml.j2
+    lstrip_blocks: true
+    trim_blocks: true
+    owner: root
+    group: root
+    mode: 0640

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,7 +5,7 @@
     src: static.yaml.j2
     lstrip_blocks: true
     trim_blocks: true
-    owner: "{{ traefik _user }}"
+    owner: "{{ traefik_user }}"
     group: "{{ traefik_group }}"
     mode: 0640
   register: _traefik_restart
@@ -16,6 +16,6 @@
     src: dynamic.yaml.j2
     lstrip_blocks: true
     trim_blocks: true
-    owner: "{{ traefik _user }}"
+    owner: "{{ traefik_user }}"
     group: "{{ traefik_group }}"
     mode: 0640

--- a/tasks/install_binary.yml
+++ b/tasks/install_binary.yml
@@ -1,0 +1,57 @@
+---
+- name: Generate systemd service file
+  template:
+    dest: /etc/systemd/system/traefik.service
+    src: traefik.service.j2
+    owner: root
+    group: root
+    mode: 0640
+  notify: daemon_reload
+
+- name: Check installed version
+  shell:
+    executable: /bin/bash
+    cmd: set -o pipefail && traefik version | head -1 | grep -Po '[\d\.]+'
+  register: _traefik_installed
+  changed_when: false
+  failed_when: false
+
+- name: Check latest release name
+  shell:
+    cmd: >
+      curl -sH "Accept: application/vnd.github.v3+json" https://api.github.com/repos/traefik/traefik/releases/latest | grep -Po '"tag_name": "\K.*?(?=")'
+    warn: false
+  changed_when: false
+  register: _traefik_release
+  when: traefik_version == 'latest'
+
+- name: Get traefik version number
+  set_fact:
+    _traefik_version: "{{ (traefik_version == 'latest') | ternary(_traefik_release.stdout, traefik_version) | regex_replace('[a-z]') }}"
+
+- when: _traefik_version is version(_traefik_installed.stdout | default('0', true), '!=' )
+  block:
+    - name: Stop service before update
+      systemd:
+        name: traefik.service
+        state: stopped
+
+    - name: Download and extract archive
+      unarchive:
+        dest: /tmp
+        src: "https://github.com/traefik/traefik/releases/download/v{{ _traefik_version }}/traefik_v{{ _traefik_version }}_linux_amd64.tar.gz"
+        remote_src: true
+        list_files: false
+        keep_newer: false
+        mode: 0640
+
+    - name: Copy binary to install location
+      copy:
+        dest: "{{ traefik_install_path }}"
+        src: /tmp/traefik
+        remote_src: true
+        force: true
+        owner: root
+        group: root
+        mode: 0755
+      notify: traefik_start

--- a/tasks/install_container.yml
+++ b/tasks/install_container.yml
@@ -1,0 +1,34 @@
+---
+- name: Ensure traefik docker network state
+  docker_network:
+    name: "{{ traefik_docker_network }}"
+    state: present
+
+- name: Launch traefik container
+  docker_container:
+    name: traefik
+    image: traefik:latest
+    pull: true
+    ignore_image: false
+    state: started
+    recreate: false
+    restart: "{{ traefik_config.results.0.changed | default(false) }}"
+    restart_policy: unless-stopped
+    container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
+    networks:
+      - name: "{{ traefik_docker_network }}"
+    networks_cli_compatible: true
+    network_mode: default
+    security_opts:
+      - no-new-privileges:true
+    published_ports:
+      - "80:80"
+      - "443:443"
+    command:
+      - --configfile "{{ traefik_configfile_static }}"
+    env: "{{ traefik_env }}"
+    volumes: "{{ traefik_mount_volumes | select | list }}"
+  vars:
+    traefik_mount_volumes:
+      - "{{ traefik_data }}:{{ traefik_data }}"
+      - "{{ traefik_provider_docker_endpoint | ternary('', '/var/run/docker.sock:/var/run/docker.sock:ro') }}"

--- a/tasks/install_container.yml
+++ b/tasks/install_container.yml
@@ -7,7 +7,7 @@
 - name: Launch traefik container
   docker_container:
     name: traefik
-    image: traefik:latest
+    image: "traefik:{{ traefik_version }}"
     pull: true
     ignore_image: false
     state: started

--- a/tasks/install_container.yml
+++ b/tasks/install_container.yml
@@ -30,5 +30,5 @@
     volumes: "{{ traefik_mount_volumes | select | list }}"
   vars:
     traefik_mount_volumes:
-      - "{{ traefik_data }}:{{ traefik_data }}"
+      - "{{ traefik_home }}:{{ traefik_home }}"
       - "{{ traefik_provider_docker_endpoint | ternary('', '/var/run/docker.sock:/var/run/docker.sock:ro') }}"

--- a/tasks/install_container.yml
+++ b/tasks/install_container.yml
@@ -12,7 +12,7 @@
     ignore_image: false
     state: started
     recreate: false
-    restart: "{{ traefik_config.results.0.changed | default(false) }}"
+    restart: "{{ _traefik_restart.changed | default(false) }}"
     restart_policy: unless-stopped
     container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
     networks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,76 +4,15 @@
   import_tasks: assert.yml
   tags: traefik, assert
 
-- name: Ensure traefik docker network state
-  docker_network:
-    name: "{{ traefik_docker_network }}"
-    state: present
-  tags: traefik, traefik-networks
+- name: Run pre-installation tasks
+  import_tasks: preinstall.yml
+  tags: traefik, traefik-preinstall
 
-- name: Ensure traefik data directory state
-  become: true
-  file:
-    path: "{{ traefik_data }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '750'
-  tags: traefik, traefik-dir
-
-- name: Ensure acme storage state
-  become: true
-  file:
-    path: "{{ traefik_acme_storage_file }}"
-    state: touch
-    access_time: preserve
-    modification_time: preserve
-    owner: root
-    group: root
-    mode: '600'
-  tags: traefik, traefik-acme
-
-- name: Generate traefik config files
-  become: true
-  template:
-    dest: "{{ item.dest }}"
-    src: "{{ item.src }}"
-    lstrip_blocks: true
-    trim_blocks: true
-    owner: root
-    group: root
-    mode: '640'
-  loop:
-    - { src: static.yaml.j2, dest: "{{ traefik_configfile_static }}" }
-    - { src: dynamic.yaml.j2, dest: "{{ traefik_configfile_dynamic }}" }
-  register: traefik_config
+- name: Run configuration tasks
+  import_tasks: config.yml
   tags: traefik, traefik-config
 
-- name: Launch traefik container
-  docker_container:
-    name: traefik
-    image: traefik:latest
-    pull: true
-    ignore_image: false
-    state: started
-    recreate: false
-    restart: "{{ traefik_config.results.0.changed | default(false) }}"
-    restart_policy: unless-stopped
-    container_default_behavior: "{{ (ansible_version.full is version('2.10', '>=')) | ternary('compatibility', omit) }}"
-    networks:
-      - name: "{{ traefik_docker_network }}"
-    networks_cli_compatible: true
-    network_mode: default
-    security_opts:
-      - no-new-privileges:true
-    published_ports:
-      - "80:80"
-      - "443:443"
-    command:
-      - --configfile "{{ traefik_configfile_static }}"
-    env: "{{ traefik_env }}"
-    volumes: "{{ traefik_mount_volumes | select | list }}"
-  vars:
-    traefik_mount_volumes:
-      - "{{ traefik_data }}:{{ traefik_data }}"
-      - "{{ traefik_provider_docker_endpoint | ternary('', '/var/run/docker.sock:/var/run/docker.sock:ro') }}"
-  tags: traefik, traefik-container
+- debug:
+- name: Run install method tasks
+  import_tasks: install_container.yml
+  tags: traefik, traefik-install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,9 @@
   import_tasks: config.yml
   tags: traefik, traefik-config
 
-- debug:
 - name: Run install method tasks
-  import_tasks: install_container.yml
+  include_tasks:
+    file: "install_{{ traefik_install_method }}.yml"
+    apply:
+      tags: traefik, traefik-install
   tags: traefik, traefik-install

--- a/tasks/preinstall.yml
+++ b/tasks/preinstall.yml
@@ -5,10 +5,15 @@
     state: present
     system: true
 
+- name: Get all existing system groups
+  getent:
+    database: group
+
 - name: Create traefik system user
   user:
     name: "{{ traefik_user }}"
     group: "{{ traefik_group }}"
+    groups: "{{ (traefik_provider_docker and not traefik_provider_docker_endpoint and 'docker' in getent_group) | ternary('docker', '') }}"
     comment: "Cloud Native Application Proxy"
     home: "{{ traefik_home }}"
     create_home: false

--- a/tasks/preinstall.yml
+++ b/tasks/preinstall.yml
@@ -1,11 +1,28 @@
 ---
-- name: Ensure traefik data directory state
+- name: Create traefik system group
+  group:
+    name: "{{ traefik_group }}"
+    state: present
+    system: true
+
+- name: Create traefik system user
+  user:
+    name: "{{ traefik_user }}"
+    group: "{{ traefik_group }}"
+    comment: "Cloud Native Application Proxy"
+    home: "{{ traefik_home }}"
+    create_home: false
+    shell: /bin/false
+    state: present
+    system: true
+
+- name: Create traefik data directory
   become: true
   file:
     path: "{{ traefik_home }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ traefik _user }}"
+    group: "{{ traefik_group }}"
     mode: 0755
 
 - name: Ensure acme storage state
@@ -15,6 +32,6 @@
     state: touch
     access_time: preserve
     modification_time: preserve
-    owner: root
-    group: root
+    owner: "{{ traefik _user }}"
+    group: "{{ traefik_group }}"
     mode: 0600

--- a/tasks/preinstall.yml
+++ b/tasks/preinstall.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure traefik data directory state
+  become: true
+  file:
+    path: "{{ traefik_data }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Ensure acme storage state
+  become: true
+  file:
+    path: "{{ traefik_acme_storage_file }}"
+    state: touch
+    access_time: preserve
+    modification_time: preserve
+    owner: root
+    group: root
+    mode: 0600

--- a/tasks/preinstall.yml
+++ b/tasks/preinstall.yml
@@ -21,7 +21,7 @@
   file:
     path: "{{ traefik_home }}"
     state: directory
-    owner: "{{ traefik _user }}"
+    owner: "{{ traefik_user }}"
     group: "{{ traefik_group }}"
     mode: 0755
 
@@ -32,6 +32,6 @@
     state: touch
     access_time: preserve
     modification_time: preserve
-    owner: "{{ traefik _user }}"
+    owner: "{{ traefik_user }}"
     group: "{{ traefik_group }}"
     mode: 0600

--- a/tasks/preinstall.yml
+++ b/tasks/preinstall.yml
@@ -2,7 +2,7 @@
 - name: Ensure traefik data directory state
   become: true
   file:
-    path: "{{ traefik_data }}"
+    path: "{{ traefik_home }}"
     state: directory
     owner: root
     group: root

--- a/templates/traefik.service.j2
+++ b/templates/traefik.service.j2
@@ -1,0 +1,49 @@
+### {{ ansible_managed }}
+# This unit file is retrieved from traefik github repository
+# https://raw.githubusercontent.com/traefik/traefik/master/contrib/systemd/traefik.service
+
+[Unit]
+Description=Traefik
+Documentation=https://doc.traefik.io/traefik/
+After=network-online.target
+AssertFileIsExecutable={{ traefik_install_path }}
+AssertPathExists={{ traefik_configfile_static }}
+
+[Service]
+User=traefik
+Group=traefik
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+{% for key, value in traefik_env.items() %}
+Environment="{{ key }}={{ value }}"
+{% endfor %}
+
+# configure service behavior
+Type=notify
+ExecStart={{ traefik_install_path }} --configFile={{ traefik_configfile_static }}
+Restart=always
+WatchdogSec=1s
+
+# lock down system access
+# prohibit any operating system and configuration modification
+ProtectSystem=strict
+# create separate, new (and empty) /tmp and /var/tmp filesystems
+#PrivateTmp=true
+# make /home directories inaccessible
+ProtectHome=true
+# turns off access to physical devices (/dev/...)
+PrivateDevices=true
+# make kernel settings (procfs and sysfs) read-only
+ProtectKernelTunables=true
+# make cgroups /sys/fs/cgroup read-only
+ProtectControlGroups=true
+NoNewPrivileges=true
+
+# allow writing of acme.json
+ReadWritePaths={{ traefik_acme_storage_file }}
+
+# write logs to system journal
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 # vars file for traefik role
 # Config files
-traefik_configfile_static: "{{ traefik_data }}/static.yaml"
-traefik_configfile_dynamic: "{{ traefik_data }}/dynamic.yaml"
+traefik_configfile_static: "{{ traefik_home }}/static.yaml"
+traefik_configfile_dynamic: "{{ traefik_home }}/dynamic.yaml"
 
 # ACME storage file
-traefik_acme_storage_file: "{{ traefik_data }}/acme.json"
+traefik_acme_storage_file: "{{ traefik_home }}/acme.json"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# vars file for traefik role
+# Config files
+traefik_configfile_static: "{{ traefik_data }}/static.yaml"
+traefik_configfile_dynamic: "{{ traefik_data }}/dynamic.yaml"
+
+# ACME storage file
+traefik_acme_storage_file: "{{ traefik_data }}/acme.json"


### PR DESCRIPTION
- Splitting tasks to separate files
- Splitting config files generation tasks
- Move some variables to vars
- Rename variable: traefik_data -> traefik_home
- Change files owner to traefik user
- Fix typo
- Binary install method with systemd service
- Disable Docker provider by default
- Set image version from variable
- Change default installation method to binary
- Update meta
- Update CI
- Add traefik user to docker group
- Update readme
